### PR TITLE
fix: include filters and query wheres in the filter

### DIFF
--- a/src/DesignMyNight/Elasticsearch/QueryGrammar.php
+++ b/src/DesignMyNight/Elasticsearch/QueryGrammar.php
@@ -543,8 +543,14 @@ class QueryGrammar extends BaseGrammar
 
         $filter = $this->compileWheres($aggregation['args']);
 
+        $filters = $filter['filter'] ?? [];
+
+        $query = $filter['query'] ?? [];
+
+        $allFilters = array_merge($query, $filters);
+
         $compiled = [
-            'filter' => $filter['filter'] ?: (object) []
+            'filter' => $allFilters ?: (object) []
         ];
 
         return $compiled;


### PR DESCRIPTION
So the filter aggregation can be created by calling `$builder->where()` or `$builder->filterWhere()` with the same effect.

FYI @DMNSteve @alasdairmackenzie