### PR TITLE
refactor: Remove else statements after return

### DIFF
--- a/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
@@ -53,7 +53,7 @@ class EloquentBuilder extends BaseBuilder
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the
         // n+1 query issue for the developers to avoid running a lot of queries.
-        else if (count($models) > 0) {
+        if (count($models) > 0) {
             $models = $builder->eagerLoadRelations($models);
         }
 
@@ -73,11 +73,10 @@ class EloquentBuilder extends BaseBuilder
         if ($results instanceof Generator){
             return $this->yieldResults($results);
         }
-        else {
-            return $this->model->hydrate(
-                $results->all()
-            )->all();
-        }
+
+        return $this->model->hydrate(
+            $results->all()
+        )->all();
     }
 
     /**

--- a/src/DesignMyNight/Elasticsearch/QueryGrammar.php
+++ b/src/DesignMyNight/Elasticsearch/QueryGrammar.php
@@ -179,9 +179,8 @@ class QueryGrammar extends BaseGrammar
 
             return $this->compileWhereBetween($builder, $where);
         }
-        else {
-            return $this->compileWhereBasic($builder, $where);
-        }
+
+        return $this->compileWhereBasic($builder, $where);
     }
 
     protected function compileWhereNested($builder, $where)

--- a/src/DesignMyNight/Elasticsearch/QueryProcessor.php
+++ b/src/DesignMyNight/Elasticsearch/QueryProcessor.php
@@ -29,15 +29,14 @@ class QueryProcessor extends BaseProcessor
         if (isset($results['_scroll_id'])){
             return $this->yieldResults($results);
         }
-        else {
-            $documents = [];
 
-            foreach ($results['hits']['hits'] as $result) {
-                $documents[] = $this->documentFromResult($result);
-            }
+        $documents = [];
 
-            return $documents;
+        foreach ($results['hits']['hits'] as $result) {
+            $documents[] = $this->documentFromResult($result);
         }
+
+        return $documents;
     }
 
     protected function yieldResults($results)


### PR DESCRIPTION
I removed some `else` statements which followed `return` statements in `if` blocks. The `else` statements are redundant due to the `return` statements so can be removed reduce indentation and make the code easier to read.