### PR TITLE
refactor: Remove if-else block

### DIFF
--- a/src/DesignMyNight/Elasticsearch/QueryBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/QueryBuilder.php
@@ -324,12 +324,8 @@ class QueryBuilder extends BaseBuilder
      */
     protected function runSelect()
     {
-        if ($this->shouldUseScroll()){
-            $this->rawResponse = $this->connection->scrollSelect($this->toCompiledQuery());
-        }
-        else {
-            $this->rawResponse = $this->connection->select($this->toCompiledQuery());
-        }
+        $strategy = $this->shouldUseScroll() ? 'scollSelect' : 'select';
+        $this->rawResponse = $this->connection->$strategy($this->toCompiledQuery());
 
         return $this->rawResponse;
     }


### PR DESCRIPTION
I've refactored the `QueryBuilder::runSelect()` method to remove the if-else conditional.

I'm not sure if this is the best approach as I don't really like method names hidden in variables. But it also removes duplication in either condition.