### PR TITLE
refactor: treat 'exists' as an operator rather than using exists method

### DIFF
--- a/src/DesignMyNight/Elasticsearch/QueryBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/QueryBuilder.php
@@ -23,6 +23,13 @@ class QueryBuilder extends BaseBuilder
     protected $scrollSelect;
 
     /**
+     * All of the supported clause operators.
+     *
+     * @var array
+     */
+    public $operators = ['=', '<', '>', '<=', '>=', '!=', 'exists'];
+
+    /**
      * Set the document type the search is targeting.
      *
      * @param string $type


### PR DESCRIPTION
An 'exists' clause has a [different meaning in SQL](http://dev.mysql.com/doc/refman/4.1/en/exists-and-not-exists-subqueries.html), so rather than reusing the Eloquent `whereExists` method we should treat 'exists' as an operator.