### PR TITLE
feat: Added support for getting aggregation results as a custom collection

### DIFF
--- a/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder as BaseBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
 
 class EloquentBuilder extends BaseBuilder
 {
@@ -58,6 +59,16 @@ class EloquentBuilder extends BaseBuilder
         }
 
         return $builder->getModel()->newCollection($models);
+    }
+
+    public function getAggregations(string $collectionClass = ''): Collection
+    {
+        $collectionClass = $collectionClass ?: Collection::class;
+
+        $this->query->get([]);
+        $aggregations = $this->query->getAggregationResults();
+
+        return new $collectionClass($aggregations);
     }
 
     /**

--- a/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
@@ -64,8 +64,6 @@ class EloquentBuilder extends BaseBuilder
     public function getAggregations(string $collectionClass = ''): Collection
     {
         $collectionClass = $collectionClass ?: Collection::class;
-
-        $this->query->get([]);
         $aggregations = $this->query->getAggregationResults();
 
         return new $collectionClass($aggregations);

--- a/src/DesignMyNight/Elasticsearch/QueryBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/QueryBuilder.php
@@ -18,6 +18,8 @@ class QueryBuilder extends BaseBuilder
 
     public $includeInnerHits;
 
+    protected $results;
+
     protected $rawResponse;
 
     protected $scrollSelect;
@@ -366,6 +368,8 @@ class QueryBuilder extends BaseBuilder
      */
     public function getAggregationResults(): array
     {
+        $this->getResultsOnce();
+
         return $this->processor->getAggregationResults();
     }
 
@@ -383,11 +387,20 @@ class QueryBuilder extends BaseBuilder
             $this->columns = $columns;
         }
 
-        $results = $this->processor->processSelect($this, $this->runSelect());
+        $results = $this->getResultsOnce();
 
         $this->columns = $original;
 
         return $this->shouldUseScroll() ? $results : collect($results);
+    }
+
+    protected function getResultsOnce(): array
+    {
+        if ($this->results === null) {
+            $this->results = $this->processor->processSelect($this, $this->runSelect());
+        }
+
+        return $this->results;
     }
 
     /**


### PR DESCRIPTION
As we talked about on Friday.

I added a new method to the `EloquentBuilder` class because I thought there'd be a couple of advantages to this approach:

* It's backwards compatible for existing code which is expecting aggregations to be returned as an array
* The method can be used similar to the `get()` method for retrieving results.

Although, on the second point, my use case is that I'm only interested in the aggregation results and not the hits. So possibly this approach doesn't work for all use cases 🤔 