### PR TITLE
fix: #21, can now specify min_doc_count and extended_bounds

### DIFF
--- a/src/DesignMyNight/Elasticsearch/QueryGrammar.php
+++ b/src/DesignMyNight/Elasticsearch/QueryGrammar.php
@@ -787,8 +787,21 @@ class QueryGrammar extends BaseGrammar
             ]
         ];
 
-        if ( is_array($aggregation['args']) && isset($aggregation['args']['interval']) ){
-            $compiled['date_histogram']['interval'] = $aggregation['args']['interval'];
+        if ( is_array($aggregation['args']) ){
+            if ( isset($aggregation['args']['interval']) ){
+                $compiled['date_histogram']['interval'] = $aggregation['args']['interval'];
+            }
+
+            if ( isset($aggregation['args']['min_doc_count']) ){
+                $compiled['date_histogram']['min_doc_count'] = $aggregation['args']['min_doc_count'];
+            }
+
+            if ( isset($aggregation['args']['extended_bounds']) && is_array($aggregation['args']['extended_bounds']) ){
+                $compiled['date_histogram']['extended_bounds'] = [];
+                $compiled['date_histogram']['extended_bounds']['min'] = $this->convertDateTime($aggregation['args']['extended_bounds'][0]);
+                $compiled['date_histogram']['extended_bounds']['max'] = $this->convertDateTime($aggregation['args']['extended_bounds'][1]);
+            }
+
         }
 
         return $compiled;


### PR DESCRIPTION
Fixes #21.

Usage:

```php
->aggregation(
    'date',
    'date_histogram',
    [
        'field' => 'date',
        'interval' => 'day',
        'min_doc_count' => 0,
        'extended_bounds' => [
            $dateFrom, // an instance of DateTime is allowed
            $dateTo
        ]
    ]
)
```