### PR TITLE
fix: querying by model type

### DIFF
--- a/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
+++ b/src/DesignMyNight/Elasticsearch/EloquentBuilder.php
@@ -25,7 +25,7 @@ class EloquentBuilder extends BaseBuilder
 
         $this->query->from($model->getSearchIndex());
 
-        $this->query->type($model->getSearchType());
+        $this->query->whereType($model->getSearchType());
 
         return $this;
     }


### PR DESCRIPTION
I tried to use the setModel() function but the type isn't used in the ES query. It looks like the `type` method is used for inserts, updates, and deletes but the `whereType` method is used for selects.