### PR TITLE
Query helper

### DIFF
--- a/src/DesignMyNight/Elasticsearch/Searchable.php
+++ b/src/DesignMyNight/Elasticsearch/Searchable.php
@@ -123,7 +123,7 @@ trait Searchable {
         return new Collection($models);
     }
 
-    public static function newElasticSearchQuery(): EloquentBuilder
+    public static function newElasticsearchQuery(): EloquentBuilder
     {
         $model = new static();
 

--- a/src/DesignMyNight/Elasticsearch/Searchable.php
+++ b/src/DesignMyNight/Elasticsearch/Searchable.php
@@ -3,6 +3,11 @@
 namespace DesignMyNight\Elasticsearch;
 
 trait Searchable {
+    public static function getElasticsearchConnectionName(): string
+    {
+        return 'elasticsearch';
+    }
+
     /**
      * Get the index this model is to be added to
      *
@@ -33,7 +38,7 @@ trait Searchable {
     {
         $originalConnection = $this->getConnectionName();
 
-        $this->setConnection('elasticsearch');
+        $this->setConnection(static::getElasticsearchConnectionName());
 
         $result = $callback(...array_slice(func_get_args(), 1));
 
@@ -116,5 +121,12 @@ trait Searchable {
     public function newCollection(array $models = array())
     {
         return new Collection($models);
+    }
+
+    public static function newElasticSearchQuery(): EloquentBuilder
+    {
+        $model = new static();
+
+        return $model->on(static::getElasticsearchConnectionName())->setModel($model);
     }
 }


### PR DESCRIPTION
I added some methods to my Model class which I thought might be useful as part of the `Searchable` trait.

`newElasticsearchQuery()` is similar to Eloquent's `newQuery(). Together with `getElasticsearchConnectionName()` it allows client code to avoid having the ES connection name duplicated whenever an ES query is made.

`newElasticsearchQuery()` also ensures that only models of the same type are returned.