### PR TITLE
feat: add option for request timeout

### DIFF
--- a/src/DesignMyNight/Elasticsearch/Connection.php
+++ b/src/DesignMyNight/Elasticsearch/Connection.php
@@ -18,6 +18,8 @@ class Connection extends BaseConnection
 
     protected $indexSuffix = '';
 
+    protected $requestTimeout;
+
     /**
      * Create a new Elasticsearch connection instance.
      *
@@ -158,7 +160,7 @@ class Connection extends BaseConnection
      */
     public function select($params, $bindings = [])
     {
-        return $this->connection->search($params);
+        return $this->connection->search($this->addClientParams($params));
     }
 
     /**
@@ -232,13 +234,13 @@ class Connection extends BaseConnection
     /**
      * Run an insert statement against the database.
      *
-     * @param  array  $query
-     * @param  array   $bindings
+     * @param  array  $params
+     * @param  array  $bindings
      * @return bool
      */
     public function insert($params, $bindings = [])
     {
-        return $this->connection->bulk($params);
+        return $this->connection->bulk($this->addClientParams($params));
     }
 
     /**
@@ -374,6 +376,41 @@ class Connection extends BaseConnection
     public function pretend(Closure $callback)
     {
 
+    }
+
+    /**
+     * Get the timeout for the entire Elasticsearch request
+     * @return float
+     */
+    public function getRequestTimeout(): float
+    {
+        return $this->requestTimeout;
+    }
+
+    /**
+     * Get the timeout for the entire Elasticsearch request
+     * @param float $requestTimeout
+     * @return self
+     */
+    public function setRequestTimeout(float $requestTimeout): self
+    {
+        $this->requestTimeout = $requestTimeout;
+
+        return $this;
+    }
+
+    /**
+     * Add client-specific parameters to the request params
+     * @param array $params
+     * @return array
+     */
+    protected function addClientParams(array $params): array
+    {
+        if ($this->requestTimeout){
+            $params['client']['timeout'] = $this->requestTimeout;
+        }
+
+        return $params;
     }
 
     /**

--- a/src/DesignMyNight/Elasticsearch/Connection.php
+++ b/src/DesignMyNight/Elasticsearch/Connection.php
@@ -389,7 +389,7 @@ class Connection extends BaseConnection
 
     /**
      * Get the timeout for the entire Elasticsearch request
-     * @param float $requestTimeout
+     * @param float $requestTimeout seconds
      * @return self
      */
     public function setRequestTimeout(float $requestTimeout): self


### PR DESCRIPTION
@alasdairmackenzie I've made a similar change to this in core (designmynight/dmn#23596), adding the ability to set a connection timeout so we don't get Apache processes tied up waiting for Elasticsearch if it's unresponsive.

I've left this with no default, but consumers could do this to set it
`$query->getConnection()->setRequestTimeout(5);`

There are other client params you can pass to Elasticsearch (eg connection_timeout) that I haven't included here, but that I've assumed will be added in future with my generic naming of `addClientParams()`