### PR TITLE
fix: closes #34 by determining the clause term key instead of using type

### DIFF
--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -641,9 +641,11 @@ class QueryGrammar extends BaseGrammar
             return $clause[$firstKey]['boost'] = $value;
         }
 
+        $key = key($clause['term']);
+
         $clause['term'] = [
-            'type' => [
-                'value' => $clause['term']['type'],
+            $key => [
+                'value' => $clause['term'][$key],
                 'boost' => $value
             ]
         ];


### PR DESCRIPTION
@willtj Made a change so that any field can have a boost applied to it