### PR TITLE
feat: add ability to apply function scores

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -362,6 +362,27 @@ class QueryBuilder extends BaseBuilder
     }
 
     /**
+     * Adds a function score of any type
+     *
+     * @param  string  $field
+     * @param  array  $options see elastic search docs for options
+     * @param  string  $boolean
+     * @return self
+     */
+    public function functionScore($functionType, $options = [], $boolean = 'and'): self
+    {
+        $where  = [
+            'type' => 'FunctionScore',
+            'function_type' => $functionType,
+            'boolean' => $boolean
+        ];
+
+        $this->wheres[]  = array_merge($where, $options);
+
+        return $this;
+    }
+
+    /**
      * Get the aggregations returned from query
      *
      * @return array

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -453,7 +453,7 @@ class QueryGrammar extends BaseGrammar
 
         $query = [
             'function_score' => [
-                $where['function_type']=> $cleanWhere
+                $where['function_type'] => $cleanWhere
             ]
         ];
 

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -434,6 +434,32 @@ class QueryGrammar extends BaseGrammar
         return $query;
     }
 
+     /**
+     * Compile where for function score
+     *
+     * @param Builder $builder
+     * @param array $where
+     * @return array
+     */
+    protected function compileWhereFunctionScore(Builder $builder, array $where): array
+    {
+        $cleanWhere = $where;
+
+        unset(
+            $cleanWhere['function_type'],
+            $cleanWhere['type'],
+            $cleanWhere['boolean']
+        );
+
+        $query = [
+            'function_score' => [
+                $where['function_type']=> $cleanWhere
+            ]
+        ];
+
+        return $query;
+    }
+
     /**
      * Compile a where nested geo distance clause
      *


### PR DESCRIPTION
@willtj I've added the ability to function score.  https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html

For example:

```php
$this->queryBuilder->functionScore('field_value_factor',[
  'factor' =>  1,
  'missing' => 1,
  'field' => 'object.page_options.search_boost',
  'modifier' => 'log'
]);

```

I went through a number of iterations on this, originally using only allowing `field_value_factor`.  I wanted to make this flexible to save having to implement each type of function score.  That makes the code a little more elastic search specific.  

Not sure how else would be best to approach without inlining the ES specific params.

Thoughts?