### PR TITLE
Add support for a single object argument to QueryBuilder::aggregation()

### DIFF
--- a/src/Aggregation.php
+++ b/src/Aggregation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DesignMyNight\Elasticsearch;
+
+abstract class Aggregation
+{
+    protected $arguments = [];
+    protected $key = '';
+    protected $type = '';
+
+    public function __invoke(QueryBuilder $query): QueryBuilder
+    {
+        return $query;
+    }
+
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -313,8 +313,21 @@ class QueryBuilder extends BaseBuilder
      * @param  null $aggregations
      * @return self
      */
-    public function aggregation($key, $type, $args = null, $aggregations = null): self
+    public function aggregation($key, $type = null, $args = null, $aggregations = null): self
     {
+        if ($key instanceof Aggregation) {
+            $aggregation = $key;
+
+            $this->aggregations[] = [
+                'key' => $aggregation->getKey(),
+                'type' => $aggregation->getType(),
+                'args' => $aggregation->getArguments(),
+                'aggregations' => $aggregation($this->newQuery()),
+            ];
+
+            return $this;
+        }
+
         if (!is_string($args) && is_callable($args)){
             call_user_func($args, $args = $this->newQuery());
         }


### PR DESCRIPTION
This expands my previous PR which added the ability to pass an objedct as the last parameter of the aggregation method.

With this PR an object can be the only argument to `aggregation()` so that an aggregation object can include the key, type, and arguments for the aggregation as well as building the aggregation.

Slack me when you read this and I'll send you a link showing this PR being used as an example of the use case.