### PR TITLE
fix: query events not fired by calling BaseConnection::run()

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -160,7 +160,11 @@ class Connection extends BaseConnection
      */
     public function select($params, $bindings = [])
     {
-        return $this->connection->search($this->addClientParams($params));
+        return $this->run(
+            $this->addClientParams($params),
+            $bindings,
+            Closure::fromCallable([$this->connection, 'search'])
+        );
     }
 
     /**
@@ -240,7 +244,11 @@ class Connection extends BaseConnection
      */
     public function insert($params, $bindings = [])
     {
-        return $this->connection->bulk($this->addClientParams($params));
+        return $this->run(
+            $this->addClientParams($params),
+            $bindings,
+            Closure::fromCallable([$this->connection, 'bulk'])
+        );
     }
 
     /**
@@ -252,7 +260,11 @@ class Connection extends BaseConnection
      */
     public function update($query, $bindings = [])
     {
-        return $this->connection->index($query);
+        return $this->run(
+            $query,
+            $bindings,
+            Closure::fromCallable([$this->connection, 'index'])
+        );
     }
 
     /**
@@ -264,7 +276,11 @@ class Connection extends BaseConnection
      */
     public function delete($query, $bindings = [])
     {
-        return $this->connection->delete($query);
+        return $this->run(
+            $query,
+            $bindings,
+            Closure::fromCallable([$this->connection, 'delete'])
+        );
     }
 
     /**


### PR DESCRIPTION
This updates the query execution methods to use the `run` method provided by `Illuminate\Database\Connection` (https://github.com/laravel/framework/blob/56a58e0fa3d845bb992d7c64ac9bb6d0c24b745a/src/Illuminate/Database/Connection.php#L614)

This ensures that events are fired when queries are executed, making it possibly to easily get the execution time of a query:

```
DB::listen(function($query) {
     // $query->sql
     // $query->bindings
     // $query->time
});
```

For logging purposes this still isn't entirely useful as the query SQL will contain any bindings. It might be helpful to look whether we could extend the base connection class in some way so that, although Elasticsearch doesn't use bind parameters, they would still be used within this library for comparing queries with different parameters.