### PR TITLE
fix: if argument to convertDateTime is a string then don't attempt to format it

### DIFF
--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1078,6 +1078,10 @@ class QueryGrammar extends BaseGrammar
      */
     protected function convertDateTime($value): string
     {
+        if (is_string($value)) {
+            return $value;
+        }
+
         return $value->format('Y-m-d\TH:i:s');
     }
 


### PR DESCRIPTION
I'm trying to use the `extended_bounds` parameter for the data histogram aggregation which was added in https://github.com/designmynight/laravel-elasticsearch/pull/22.

Because I'm stupid my mappings specified a different date format to the one being used at https://github.com/designmynight/laravel-elasticsearch/blob/30974149a8cfda92f1e161b0c10abbc8a679d587/src/DesignMyNight/Elasticsearch/QueryGrammar.php#L1018

I've got a method which I already use to pass an array of dates in the correct format. But this isn't working at the moment because `->format()` is being called on a string.

I'm not sure that this check belongs in the `convertDateTime` method but it seemed tidier than changing the `compileDateHistogramAggregation` method. Also, as there's no typehint on the `convertDateTime` it's possible that a string could be passed in from other places.