### PR TITLE
feat: index migration aliases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size=2

--- a/src/Console/Mappings/AliasMakeCommand.php
+++ b/src/Console/Mappings/AliasMakeCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace DesignMyNight\Elasticsearch\Console\Mappings;
+
+use Carbon\Carbon;
+use DesignMyNight\Elasticsearch\Console\Mappings\Traits\GetsIndices;
+use Exception;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * Class MappingMakeCommand
+ *
+ * @package DesignMyNight\Elasticsearch\Console\Mappings
+ */
+class AliasMakeCommand extends Command
+{
+
+    use GetsIndices;
+
+    /** @var string $description */
+    protected $description = 'Create new alias.';
+
+    /** @var Filesystem $files */
+    protected $files;
+
+    /** @var string $signature */
+    protected $signature = 'make:mapping-alias {name : Name of the mapping alias.} {index? : Name of index to point to}';
+
+    /**
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            $aliasName = $this->argument('name');
+            $indexName = $this->getIndexName();
+
+            if($this->client->indices()->existsAlias(['name' => $aliasName])){
+                throw new Exception("Alias $aliasName already exists");
+            }
+
+            $this->client->indices()->putAlias([
+              'index' => $indexName,
+              'name' => $aliasName
+            ]);
+        }
+        catch (Exception $exception) {
+            $this->error($exception->getMessage());
+
+            return;
+        }
+
+        $this->info("Alias $aliasName created successfully.");
+    }
+
+    /**
+     * @return string
+     */
+    protected function getIndexName():string
+    {
+        if (!$indexName = $this->argument('index')) {
+            $indices = collect($this->getIndices())
+              ->sortBy('index')
+              ->pluck('index')
+              ->toArray();
+
+            $indexName = $this->choice('Which index do you want to create an alias for?', $indices);
+        }
+
+        return $indexName;
+    }
+}

--- a/src/Console/Mappings/IndexListCommand.php
+++ b/src/Console/Mappings/IndexListCommand.php
@@ -2,6 +2,7 @@
 
 namespace DesignMyNight\Elasticsearch\Console\Mappings;
 
+use DesignMyNight\Elasticsearch\Console\Mappings\Traits\GetsIndices;
 use Elasticsearch\ClientBuilder;
 use Illuminate\Support\Collection;
 
@@ -12,6 +13,8 @@ use Illuminate\Support\Collection;
  */
 class IndexListCommand extends Command
 {
+
+    use GetsIndices;
 
     /** @var string $description */
     protected $description = 'View all Elasticsearch indices';
@@ -59,21 +62,6 @@ class IndexListCommand extends Command
 
             $this->table(array_keys($indices[0]), $indices);
         }
-    }
-
-    /**
-     * @return array
-     */
-    protected function getIndices():array
-    {
-        try {
-            return collect($this->client->cat()->indices())->sortBy('index')->toArray();
-        }
-        catch (\Exception $exception) {
-            $this->error('Failed to retrieve indices.');
-        }
-
-        return [];
     }
 
     /**

--- a/src/Console/Mappings/MappingMigrateCommand.php
+++ b/src/Console/Mappings/MappingMigrateCommand.php
@@ -172,11 +172,11 @@ class MappingMigrateCommand extends Command
 
         $batch = $this->connection->max('batch') + 1;
 
+        $createdAliases = [];
+
         foreach ($pending as $mapping) {
             $index = $this->getMappingName($mapping->getFileName());
             $aliasName = $this->getAlias($index);
-
-            $createdIndex = false;
 
             try {
                 $this->call('make:mapping-alias', [
@@ -184,7 +184,7 @@ class MappingMigrateCommand extends Command
                   'index' => $index
                 ]);
 
-                $createdIndex = true;
+                $createdAliases[] = $aliasName;
             }
             catch(\Exception $e) {
                 // ignore
@@ -208,7 +208,7 @@ class MappingMigrateCommand extends Command
             if (!str_contains($index, 'update') && $this->option('index')) {
                 $this->index($index);
 
-                if ($createdIndex || $this->option('swap')) {
+                if (in_array($aliasName, $createdAliases) || $this->option('swap')) {
                     $this->updateAlias($this->getMappingName($index, true));
                 }
             }

--- a/src/Console/Mappings/MappingMigrateCommand.php
+++ b/src/Console/Mappings/MappingMigrateCommand.php
@@ -20,9 +20,6 @@ class MappingMigrateCommand extends Command
     use HasConnection;
     use UpdatesAlias;
 
-    /** @var Filesystem $files */
-    public $files;
-
     /** @var string $description */
     protected $description = 'Index new mapping';
 

--- a/src/Console/Mappings/MappingMigrateCommand.php
+++ b/src/Console/Mappings/MappingMigrateCommand.php
@@ -174,6 +174,21 @@ class MappingMigrateCommand extends Command
 
         foreach ($pending as $mapping) {
             $index = $this->getMappingName($mapping->getFileName());
+            $aliasName = $this->getAlias($index);
+
+            $createdIndex = false;
+
+            try {
+                $this->call('make:mapping-alias', [
+                  'name' => $aliasName,
+                  'index' => $index
+                ]);
+
+                $createdIndex = true;
+            }
+            catch(\Exception $e) {
+                // ignore
+            }
 
             $this->info("Migrating mapping: {$index}");
 
@@ -193,7 +208,7 @@ class MappingMigrateCommand extends Command
             if (!str_contains($index, 'update') && $this->option('index')) {
                 $this->index($index);
 
-                if ($this->option('swap')) {
+                if ($createdIndex || $this->option('swap')) {
                     $this->updateAlias($this->getMappingName($index, true));
                 }
             }

--- a/src/Console/Mappings/Traits/GetsIndices.php
+++ b/src/Console/Mappings/Traits/GetsIndices.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: james.osullivan
+ * Date: 03/08/2018
+ * Time: 14:29
+ */
+
+namespace DesignMyNight\Elasticsearch\Console\Mappings\Traits;
+
+trait GetsIndices
+{
+    /**
+     * @return array
+     */
+    protected function getIndices():array
+    {
+        try {
+            return collect($this->client->cat()->indices())->sortBy('index')->toArray();
+        }
+        catch (\Exception $exception) {
+            $this->error('Failed to retrieve indices.');
+        }
+
+        return [];
+    }
+}

--- a/src/Console/Mappings/Traits/UpdatesAlias.php
+++ b/src/Console/Mappings/Traits/UpdatesAlias.php
@@ -47,7 +47,7 @@ trait UpdatesAlias
      */
     protected function getAlias(string $mapping):string
     {
-        return preg_replace('/[0-9_]+/', '', $mapping, 1);
+        return preg_replace('/^\d{4}\_\d{2}\_\d{2}\_\d{6}\_/', '', $mapping, 1);
     }
 
     /**

--- a/tests/Console/Mappings/MappingMigrateCommandTest.php
+++ b/tests/Console/Mappings/MappingMigrateCommandTest.php
@@ -63,11 +63,11 @@ class MappingMigrateCommandTest extends TestCase
      * @covers       MappingMigrateCommand::getMappingName()
      * @dataProvider get_mapping_name_data_provider
      */
-    public function it_gets_the_mapping_name($expected, $withSuffix = false)
+    public function it_gets_the_mapping_name($expected, $filename, $withSuffix = false)
     {
         config(['database.connections.elasticsearch.suffix' => '_dev']);
 
-        $this->assertEquals($expected, $this->command->getMappingName('mapping_filename.json', $withSuffix));
+        $this->assertEquals($expected, $this->command->getMappingName($filename, $withSuffix));
     }
 
     /**
@@ -76,8 +76,8 @@ class MappingMigrateCommandTest extends TestCase
     public function get_mapping_name_data_provider():array
     {
         return [
-            'removes file extension' => ['mapping_filename'],
-            'appends suffix'         => ['mapping_filename_dev', true],
+            'removes file extension' => ['mapping_filename', 'mapping_filename.json'],
+            'appends suffix'         => ['mapping_filename_dev', 'mapping_filename.json', true],
         ];
     }
 
@@ -193,12 +193,17 @@ class MappingMigrateCommandTest extends TestCase
 
             $this->command
                 ->shouldReceive('option')
+                ->atMost()
                 ->once()
                 ->with('swap')
                 ->andReturn($options['swap_alias']);
         }
 
-        if ($options['swap_alias']) {
+        $this->command->shouldReceive('call')
+            ->once()
+            ->with('make:mapping-alias', ['name' => 'pending_mapping', 'index' => 'pending_mapping']);
+
+        if($options['automatically_index']){
             $this->command
                 ->shouldReceive('updateAlias')
                 ->once()


### PR DESCRIPTION
@willtj 
This is an update to automatically add index aliasing for migration

When creating an index through migrations the package currently creates the index named with the timestamp of the migration.  I.e. `2018_08_02_162200_indexname`

For a friendlier way of of referring to the index one can use an alias.  In fact migration already supports automatically swapping the alias during an 'update' migration.

This PR allows you to create an alias with `php artisan make:mapping-alias`

But also, when you run the migration it will assume you want an alias and not use that timestamp. So when you migrate it will create the alias `indexname` for `2018_08_02_162200_indexname`

Also covered that if you are running migrations for the first time it will ensure the alias points to the last (most up to date) index.