### PR TITLE
fix: don't try to include the query/bindings

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -348,6 +348,28 @@ class Connection extends BaseConnection
     }
 
     /**
+     * Run a search query.
+     *
+     * @param  array     $query
+     * @param  array     $bindings
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @throws \DesignMyNight\Elasticsearch\QueryException
+     */
+    protected function runQueryCallback($query, $bindings, Closure $callback)
+    {
+        try {
+            $result = $callback($query, $bindings);
+        }
+        catch (Exception $e) {
+            throw new QueryException($query, null, $e);
+        }
+
+        return $result;
+    }
+
+    /**
      * Execute a Closure within a transaction.
      *
      * @param  \Closure  $callback

--- a/src/QueryException.php
+++ b/src/QueryException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DesignMyNight\Elasticsearch;
+
+use Illuminate\Database\QueryException as BaseQueryException;
+
+class QueryException extends BaseQueryException
+{
+     /**
+     * Format the error message.
+     *
+     * @param  array  $query
+     * @param  array  $bindings
+     * @param  \Exception $previous
+     * @return string
+     */
+    protected function formatMessage($query, $bindings, $previous)
+    {
+        return $previous->getMessage();
+    }
+}


### PR DESCRIPTION
Because the ES query is an array so can't neatly be included  in the exception message like an SQL query could.