### PR TITLE
fix: set name of connection

### DIFF
--- a/src/ElasticsearchServiceProvider.php
+++ b/src/ElasticsearchServiceProvider.php
@@ -59,6 +59,7 @@ class ElasticsearchServiceProvider extends ServiceProvider
         // Add database driver.
         $this->app->resolving('db', function (DatabaseManager $db) {
             $db->extend('elasticsearch', function ($config) {
+                $config['name'] = $name;
                 return new Connection($config);
             });
         });


### PR DESCRIPTION
Default DatabaseManager disconnect() method tries to disconnect connections by name and no name was defaulting to the default connection being disconnected when an ES query was executed.