### PR TITLE
fix: remove update when getting alias name

### DIFF
--- a/src/Console/Mappings/Traits/UpdatesAlias.php
+++ b/src/Console/Mappings/Traits/UpdatesAlias.php
@@ -47,7 +47,7 @@ trait UpdatesAlias
      */
     protected function getAlias(string $mapping):string
     {
-        return preg_replace('/^\d{4}\_\d{2}\_\d{2}\_\d{6}\_/', '', $mapping, 1);
+        return preg_replace('/^\d{4}\_\d{2}\_\d{2}\_\d{6}\_(update_)?/', '', $mapping, 1);
     }
 
     /**


### PR DESCRIPTION
"update" wasn't being removed from index name when getting the alias name.