### PR TITLE
fix: still put the connection back if ES failed

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -41,9 +41,12 @@ trait Searchable {
 
         $this->setConnection(static::getElasticsearchConnectionName());
 
-        $result = $callback(...array_slice(func_get_args(), 1));
-
-        $this->setConnection($originalConnection);
+        try {
+            $result = $callback(...array_slice(func_get_args(), 1));
+        }
+        finally {
+            $this->setConnection($originalConnection);
+        }
 
         return $result;
     }


### PR DESCRIPTION
@JasparGupta this fixes an issue where the model's connection was being left as Elasticsearch if the ES operation threw an exception