### PR TITLE
Cursor method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1",
         "elasticsearch/elasticsearch": "^5.2",
-        "laravel/framework": "^5.6"
+        "laravel/framework": "^5.7"
     },
     "require-dev": {
       "phpunit/phpunit": "^7.1",

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -232,7 +232,7 @@ class Connection extends BaseConnection
      * @param  int $limit
      * @return \Generator
      */
-    public function scroll(string $scrollId, string $scrollTimeout = '30s', int $limit = null)
+    public function scroll(string $scrollId, string $scrollTimeout = '30s', int $limit = 0)
     {
         $numResults = 0;
 


### PR DESCRIPTION
Adds the `cursor()` method that's part of Laravel 5.7 and removes the previous way of returning a generator for a query.