### PR TITLE
fix: declaration of Client::rollback()

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -419,7 +419,7 @@ class Connection extends BaseConnection
      *
      * @return void
      */
-    public function rollBack()
+    public function rollBack($toLevel = null)
     {
 
     }


### PR DESCRIPTION
FYI @willtj 

```
Declaration of DesignMyNight\Elasticsearch\Connection::rollBack() must be compatible with Illuminate\Database\Connection::rollBack($toLevel = NULL)  
```