### PR TITLE
refactor: pass connection when hydrating a model

### DIFF
--- a/src/EloquentBuilder.php
+++ b/src/EloquentBuilder.php
@@ -74,6 +74,18 @@ class EloquentBuilder extends BaseBuilder
     }
 
     /**
+     * @inheritdoc
+     */
+    public function hydrate(array $items)
+    {
+        $instance = $this->newModelInstance();
+
+        return $instance->newCollection(array_map(function ($item) use ($instance) {
+            return $instance->newFromBuilder($item, $this->getConnection()->getName());
+        }, $items));
+    }
+
+    /**
      * Get a generator for the given query.
      *
      * @return Generator

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1093,7 +1093,15 @@ class QueryGrammar extends BaseGrammar
             return $value;
         }
 
-        return $value->format('Y-m-d\TH:i:s');
+        return $value->format($this->getDateFormat());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDateFormat():string
+    {
+        return 'Y-m-d\TH:i:s';
     }
 
     /**


### PR DESCRIPTION
So I've had a mammoth of a hard time with date formats involving hydrating models using the correct format. 

This should help solve the issue I've had where Carbon/Laravel has been trying to automatically parse dates behind the scenes where I need the date format to be `Y-m-d\TH:i:s` coming from Elasticsearch as thats how they're stored by default. But I also need the date format to be `Y-m-d H:i:s` when being returned from MongoDB.

However when calling `::hydrate()` without passing the connection, it defaults to Mongo, and throws a hissy fit.