### PR TITLE
2.1 fix deleting child documents

### DIFF
--- a/src/EloquentBuilder.php
+++ b/src/EloquentBuilder.php
@@ -89,7 +89,21 @@ class EloquentBuilder extends BaseBuilder
     }
 
     /**
-     * Return new models as a generator
+     * @inheritdoc
+     */
+    public function hydrate(array $items)
+    {
+        $instance = $this->newModelInstance();
+
+        return $instance->newCollection(array_map(function ($item) use ($instance) {
+            return $instance->newFromBuilder($item, $this->getConnection()->getName());
+        }, $items));
+    }
+
+    /**
+     * Get a generator for the given query.
+     *
+     * @return Generator
      */
     protected function yieldResults($results)
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -18,6 +18,8 @@ class QueryBuilder extends BaseBuilder
 
     public $includeInnerHits;
 
+    protected $parentId;
+
     protected $results;
 
     protected $rawResponse;
@@ -43,6 +45,29 @@ class QueryBuilder extends BaseBuilder
         $this->type = $type;
 
         return $this;
+    }
+
+    /**
+     * Set the parent ID to be used when routing queries to Elasticsearch
+     *
+     * @param  string $id
+     * @return Builder
+     */
+    public function parentId(string $id): self
+    {
+        $this->parentId = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the parent ID to be used when routing queries to Elasticsearch
+     *
+     * @return string|null
+     */
+    public function getParentId(): ?string
+    {
+        return $this->parentId;
     }
 
     /**

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1038,7 +1038,10 @@ class QueryGrammar extends BaseGrammar
                 '_id'    => $doc['id'],
             ];
 
-            if (isset($doc['_parent'])) {
+            if ($parentId = $builder->getParentId()) {
+                $index['parent'] = $parentId;
+            }
+            else if (isset($doc['_parent'])) {
                 $index['parent'] = $doc['_parent'];
                 unset($doc['_parent']);
             }
@@ -1066,6 +1069,10 @@ class QueryGrammar extends BaseGrammar
             'type'  => $builder->type,
             'id'    => (string) $builder->wheres[0]['value']
         ];
+
+        if ($parentId = $builder->getParentId()) {
+            $params['parent'] = $parentId;
+        }
 
         return $params;
     }

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1093,7 +1093,15 @@ class QueryGrammar extends BaseGrammar
             return $value;
         }
 
-        return $value->format('Y-m-d\TH:i:s');
+        return $value->format($this->getDateFormat());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDateFormat():string
+    {
+        return 'Y-m-d\TH:i:s';
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -52,6 +52,18 @@ trait Searchable
     }
 
     /**
+     * Implementing models can override this method to set additional query
+     * parameters to be used when searching
+     *
+     * @param  EloquentBuilder $query
+     * @return EloquentBuilder
+     */
+    public function setKeysForSearch(EloquentBuilder $query): EloquentBuilder
+    {
+        return $query;
+    }
+
+    /**
      * Add to search index
      *
      * @throws Exception
@@ -59,8 +71,10 @@ trait Searchable
      */
     public function addToIndex()
     {
-        return $this->onSearchConnection(function($model){
-            $query = $model->newQueryWithoutScopes();
+        return $this->onSearchConnection(function($model) {
+            $query = $model->setKeysForSaveQuery($this->newQueryWithoutScopes());
+
+            $this->setKeysForSearch($query);
 
             return $query->insert($model->toSearchableArray());
         }, $this);
@@ -83,8 +97,12 @@ trait Searchable
      */
     public function removeFromIndex()
     {
-        return $this->onSearchConnection(function($model){
-            $model->delete();
+        return $this->onSearchConnection(function($model) {
+            $query = $model->setKeysForSaveQuery($this->newQueryWithoutScopes());
+
+            $this->setKeysForSearch($query);
+
+            return $query->delete();
         }, $this);
     }
 


### PR DESCRIPTION
@robbytaylor can I get your review on this please? This is to merge into the 2.1 branch and then I'll also merge to master for a 3.0 release.

The `hydrate()` change and related date format stuff is a fix being copied over from the 3.0 branch.

The main change adds a `setKeysForSearch()` method to the Searchable trait, overridable by individual models, that will add extra query parameters to be used when searching for a document, and follows a similar approach to Laravel's Model method `setKeysForSaveQuery()`. In the Collins API codebase this will allow us to carry out actions on embedded models directly - currently doing `$deposit->delete()` throws an Elasticsearch routing exception because the deposit type is a child of a booking in Elasticsearch, and ES wants the booking ID to be passed as `parent` to be able to find the right document.