### PR TITLE
fix: require field to exist

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -292,7 +292,7 @@ class QueryBuilder extends BaseBuilder
 
         $operator = $operator == '=' ? '==' : $operator;
 
-        $script = "doc.{$column}.date.{$dateType} {$operator} params.value";
+        $script = "doc.{$column}.size() > 0 && doc.{$column}.date.{$dateType} {$operator} params.value";
 
         $options['params'] = ['value' => (int) $value];
 


### PR DESCRIPTION
Otherwise date defaults to start of epoch, so we get lots of results for DOBs in January when customers just have no DOB set.