### PR TITLE
fix: perform ES queries on cloned model

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -37,17 +37,14 @@ trait Searchable
      */
     public function onSearchConnection(\Closure $callback)
     {
-        $originalConnection = $this->getConnectionName();
+        $arguments = array_slice(func_get_args(), 1);
 
-        $this->setConnection(static::getElasticsearchConnectionName());
+        $elasticModel = clone $arguments[0];
+        $elasticModel->setConnectionName(static::getElasticsearchConnectionName());
 
-        try {
-            $result = $callback(...array_slice(func_get_args(), 1));
-        } finally {
-            $this->setConnection($originalConnection);
-        }
+        $arguments[0] = $elasticModel;
 
-        return $result;
+        return $callback(...$arguments);
     }
 
     /**


### PR DESCRIPTION
I've had an issue that was hard to debug. Eventually I figured out that the problem was due to updating a searchable model after it had been saved.

The save was changing the connection name to `elasticsearch`. The subsequent update was then running against the ElasticSearch query builder rather than the MongoDB query builder.

This should have been handled by the existing code, but it isn't. I think Laravel is being clever somewhere, I'm not sure where, and keeping the previous query builder. So changing the connection name back doesn't change the query builder instance which is used on the subsequent query.

This approach creates a copy of the model and runs the elasticsearch query on the clone, ensuring the original model retains it's initial state.