### PR TITLE
fix: only pass instance

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -18,10 +18,10 @@ class Collection extends BaseCollection
             return $model->toSearchableArray();
         });
 
-        return $instance->onSearchConnection(function ($docs, $instance) {
+        return $instance->onSearchConnection(function ($instance) use ($docs) {
             $query = $instance->newQueryWithoutScopes();
 
             return $query->insert($docs->all());
-        }, $docs, $instance);
+        }, $instance);
     }
 }


### PR DESCRIPTION
Changes in https://github.com/designmynight/laravel-elasticsearch/pull/74 assume that the instance is going to be the first argument.