### PR TITLE
Refactor date conversion

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -14,11 +14,13 @@ class Collection extends BaseCollection
 
         $instance = $this->first();
 
-        $docs = $this->map(function ($model) {
-            return $model->toSearchableArray();
-        });
+        return $instance->onSearchConnection(function ($instance) {
+            $docs = $this->map(function ($model) {
+                return $model->onSearchConnection(function ($model) {
+                    return $model->toSearchableArray();
+                }, $model);
+            });
 
-        return $instance->onSearchConnection(function ($instance) use ($docs) {
             $query = $instance->newQueryWithoutScopes();
 
             return $query->insert($docs->all());

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -139,63 +139,7 @@ trait Searchable
             }
         }
 
-        $array = $this->datesToSearchable($array);
-
         return $array;
-    }
-
-    /**
-     * Convert all dates to searchable format
-     *
-     * @param  array $array
-     * @return array
-     */
-    public function datesToSearchable(array $array): array
-    {
-        foreach ($this->getDates() as $dateField) {
-            if (isset($array[$dateField])) {
-                $array[$dateField] = $this->fromDateTimeSearchable($array[$dateField]);
-            }
-        }
-
-        foreach ($this->getArrayableRelations() as $key => $relation) {
-            $attributeName = snake_case($key);
-
-            if (isset($array[$attributeName]) && method_exists($relation, 'toSearchableArray')) {
-                $array[$attributeName] = $relation->datesToSearchable($array[$attributeName]);
-            } elseif (isset($array[$attributeName]) && $relation instanceof \Illuminate\Support\Collection) {
-                $array[$attributeName] = $relation->map(function ($item, $i) use ($array, $attributeName) {
-                    if (method_exists($item, 'toSearchableArray')) {
-                        return $item->datesToSearchable($array[$attributeName][$i]);
-                    }
-
-                    return $item;
-                })->all();
-            }
-        }
-
-        return $array;
-    }
-
-    /**
-     * Convert a DateTime to a string in ES format.
-     *
-     * @param  \DateTime|int $value
-     * @return string
-     */
-    public function fromDateTimeSearchable($value): string
-    {
-        return empty($value) ? $value : $this->asDateTime($value)->format($this->getSearchableDateFormat());
-    }
-
-    /**
-     * Return the format to be used for dates in Elasticsearch
-     *
-     * @return string
-     */
-    public function getSearchableDateFormat(): string
-    {
-        return 'Y-m-d\TH:i:s';
     }
 
     /**


### PR DESCRIPTION
This change removes `datesToSearchable()` which tries to format all dates in the required ES format. Turns out I only required this because in the Collins codebase the MongoDB Model class overrides Laravel's date conversion, which checks the current connection and gets the date format from the model's query grammar.

The changes in Collection make sure this still works for bulk updates by converting each model to a searchable array while on using the search connection.