### PR TITLE
feat: command to copy all documents to a new index

### DIFF
--- a/src/Console/Mappings/CopyIndexCommand.php
+++ b/src/Console/Mappings/CopyIndexCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DesignMyNight\Elasticsearch\Console\Mappings;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Class IndexListCommand
+ *
+ * @package DesignMyNight\Elasticsearch\Console\Mappings
+ */
+class CopyIndexCommand extends Command
+{
+    /**
+     * @var string $description
+     */
+    protected $description = 'Populate an index with all documents from another index';
+
+    /**
+     * @var string $signature
+     */
+    protected $signature = 'index:copy {--from= } {--to= }';
+
+    /**
+     * @var int
+     */
+    protected $batchSize = 1000;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $fromIndex = $this->option('from');
+        $toIndex = $this->option('to');
+
+        if (! $fromIndex || ! $toIndex) {
+            $this->line('You must specify a from and a to index.');
+            exit;
+        }
+
+        $bulkParams = ['body' => []];
+        $connection = DB::connection('elasticsearch');
+
+        $query = [
+            'index' => $fromIndex,
+            'body' => [
+                'query' => [
+                    'match_all' => (object) []
+                ],
+            ],
+        ];
+
+        $numResultsQuery = $query;
+        $numResultsQuery['size'] = 0;
+
+        $numResults = $connection->select($numResultsQuery)['hits']['total'];
+        $bar = $this->output->createProgressBar($numResults);
+        $bar->start();
+
+        foreach ($connection->cursor($query) as $i => $doc) {
+            $indexParams = [
+                'index' => [
+                    '_index' => $toIndex,
+                    '_type' => $doc['_type'],
+                    '_id' => $doc['_id'],
+                ],
+            ];
+
+            if (isset($doc['_parent'])) {
+                $indexParams['index']['parent'] = $doc['_parent'];
+            }
+
+            $bulkParams['body'][] = $indexParams;
+            $bulkParams['body'][] = $doc['_source'];
+
+            if (($i + 1) % $this->batchSize === 0) {
+                $responses = $connection->insert($bulkParams);
+                $bulkParams = ['body' => []];
+
+                $bar->advance($this->batchSize);
+            }
+        }
+
+        if (! empty($bulkParams['body'])) {
+            $responses = $connection->insert($bulkParams);
+        }
+
+        $bar->finish();
+    }
+}

--- a/src/Console/Mappings/CopyIndexCommand.php
+++ b/src/Console/Mappings/CopyIndexCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
  *
  * @package DesignMyNight\Elasticsearch\Console\Mappings
  */
-class CopyIndexCommand extends Command
+class IndexCopyCommand extends Command
 {
     /**
      * @var string $description
@@ -19,7 +19,7 @@ class CopyIndexCommand extends Command
     /**
      * @var string $signature
      */
-    protected $signature = 'index:copy {--from= } {--to= }';
+    protected $signature = 'index:copy {from} {to}';
 
     /**
      * @var int
@@ -33,7 +33,7 @@ class CopyIndexCommand extends Command
      */
     public function handle()
     {
-        $fromIndex = $this->option('from');
+        ['from' => $from, 'to' => $to] = $this->arguments();
         $toIndex = $this->option('to');
 
         if (! $fromIndex || ! $toIndex) {

--- a/src/Console/Mappings/IndexCopyCommand.php
+++ b/src/Console/Mappings/IndexCopyCommand.php
@@ -5,7 +5,7 @@ namespace DesignMyNight\Elasticsearch\Console\Mappings;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Class IndexListCommand
+ * Class IndexCopyCommand
  *
  * @package DesignMyNight\Elasticsearch\Console\Mappings
  */
@@ -33,13 +33,9 @@ class IndexCopyCommand extends Command
      */
     public function handle()
     {
-        ['from' => $from, 'to' => $to] = $this->arguments();
-        $toIndex = $this->option('to');
+        ['from' => $fromIndex, 'to' => $toIndex] = $this->arguments();
 
-        if (! $fromIndex || ! $toIndex) {
-            $this->line('You must specify a from and a to index.');
-            exit;
-        }
+        dd($fromIndex, $toIndex);
 
         $bulkParams = ['body' => []];
         $connection = DB::connection('elasticsearch');

--- a/src/Console/Mappings/IndexCopyCommand.php
+++ b/src/Console/Mappings/IndexCopyCommand.php
@@ -35,8 +35,6 @@ class IndexCopyCommand extends Command
     {
         ['from' => $fromIndex, 'to' => $toIndex] = $this->arguments();
 
-        dd($fromIndex, $toIndex);
-
         $bulkParams = ['body' => []];
         $connection = DB::connection('elasticsearch');
 

--- a/src/ElasticsearchServiceProvider.php
+++ b/src/ElasticsearchServiceProvider.php
@@ -3,13 +3,13 @@
 namespace DesignMyNight\Elasticsearch;
 
 use DesignMyNight\Elasticsearch\Console\Mappings\AliasMakeCommand;
-use DesignMyNight\Elasticsearch\Console\Mappings\CopyIndexCommand;
-use DesignMyNight\Elasticsearch\Console\Mappings\MappingMakeCommand;
-use DesignMyNight\Elasticsearch\Console\Mappings\MappingMigrateCommand;
+use DesignMyNight\Elasticsearch\Console\Mappings\IndexCopyCommand;
+use DesignMyNight\Elasticsearch\Console\Mappings\IndexListCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\IndexRemoveCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\IndexRollbackCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\IndexSwapCommand;
-use DesignMyNight\Elasticsearch\Console\Mappings\IndexListCommand;
+use DesignMyNight\Elasticsearch\Console\Mappings\MappingMakeCommand;
+use DesignMyNight\Elasticsearch\Console\Mappings\MappingMigrateCommand;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
 
@@ -24,13 +24,13 @@ class ElasticsearchServiceProvider extends ServiceProvider
     /** @var array $commands */
     private $commands = [
         AliasMakeCommand::class,
-        CopyIndexCommand::class,
-        MappingMakeCommand::class,
-        MappingMigrateCommand::class,
-        IndexSwapCommand::class,
+        IndexCopyCommand::class,
+        IndexListCommand::class,
         IndexRemoveCommand::class,
         IndexRollbackCommand::class,
-        IndexListCommand::class,
+        IndexSwapCommand::class,
+        MappingMakeCommand::class,
+        MappingMigrateCommand::class,
     ];
 
     /**

--- a/src/ElasticsearchServiceProvider.php
+++ b/src/ElasticsearchServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DesignMyNight\Elasticsearch;
 
 use DesignMyNight\Elasticsearch\Console\Mappings\AliasMakeCommand;
+use DesignMyNight\Elasticsearch\Console\Mappings\CopyIndexCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\MappingMakeCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\MappingMigrateCommand;
 use DesignMyNight\Elasticsearch\Console\Mappings\IndexRemoveCommand;
@@ -23,12 +24,13 @@ class ElasticsearchServiceProvider extends ServiceProvider
     /** @var array $commands */
     private $commands = [
         AliasMakeCommand::class,
+        CopyIndexCommand::class,
         MappingMakeCommand::class,
         MappingMigrateCommand::class,
         IndexSwapCommand::class,
         IndexRemoveCommand::class,
         IndexRollbackCommand::class,
-        IndexListCommand::class
+        IndexListCommand::class,
     ];
 
     /**


### PR DESCRIPTION
Uses an Elasticsearch scroll cursor to re-index all documents from one index to a new index - useful if you have updated a mapping and can reindex from existing ES data rather than having to reindex from the database.