### PR TITLE
Fix copy index command

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -206,8 +206,6 @@ class Connection extends BaseConnection
 
         $scrollId = $results['_scroll_id'];
 
-        $numFound = $results['hits']['total'];
-
         $numResults = count($results['hits']['hits']);
 
         foreach ($results['hits']['hits'] as $result) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -193,11 +193,11 @@ class Connection extends BaseConnection
     public function cursor($query, $bindings = [], $useReadPdo = false)
     {
         $scrollTimeout = '30s';
-        $limit = min($params['body']['size'] ?? 100000, 100000);
+        $limit = $query['size'] ?? 0;
 
         $scrollParams = array(
             'scroll' => $scrollTimeout,
-            'size'   => min(100, $limit),
+            'size'   => 100, // Number of results per shard
             'index'  => $query['index'],
             'body'   => $query['body']
         );
@@ -214,8 +214,10 @@ class Connection extends BaseConnection
             yield $result;
         }
 
-        if ($limit > $numResults) {
-            foreach ($this->scroll($scrollId, $scrollTimeout, $limit - $numResults) as $result) {
+        if (! $limit || $limit > $numResults) {
+            $limit = $limit ? $limit - $numResults : $limit;
+
+            foreach ($this->scroll($scrollId, $scrollTimeout, $limit) as $result) {
                 yield $result;
             }
         }
@@ -234,7 +236,7 @@ class Connection extends BaseConnection
         $numResults = 0;
 
         // Loop until the scroll 'cursors' are exhausted or we have enough results
-        while (!$limit || $numResults < $limit) {
+        while (! $limit || $numResults < $limit) {
             // Execute a Scroll request
             $results = $this->connection->scroll(array(
                 'scroll_id' => $scrollId,
@@ -252,7 +254,7 @@ class Connection extends BaseConnection
             foreach ($results['hits']['hits'] as $result) {
                 $numResults++;
 
-                if ($numResults > $limit) {
+                if ($limit && $numResults > $limit) {
                     break;
                 }
 

--- a/src/Console/Mappings/IndexCopyCommand.php
+++ b/src/Console/Mappings/IndexCopyCommand.php
@@ -40,6 +40,7 @@ class IndexCopyCommand extends Command
 
         $query = [
             'index' => $fromIndex,
+            'size' => 0,
             'body' => [
                 'query' => [
                     'match_all' => (object) []
@@ -47,10 +48,7 @@ class IndexCopyCommand extends Command
             ],
         ];
 
-        $numResultsQuery = $query;
-        $numResultsQuery['size'] = 0;
-
-        $numResults = $connection->select($numResultsQuery)['hits']['total'];
+        $numResults = $connection->select($query)['hits']['total'];
         $bar = $this->output->createProgressBar($numResults);
         $bar->start();
 


### PR DESCRIPTION
The cursor method was defaulting to 100,000 records and failing to allow it to be set to zero, so copying the index was stopping after hitting that limit.