### PR TITLE
feat: support `whereNot()`

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -202,6 +202,24 @@ class QueryBuilder extends BaseBuilder
     }
 
     /**
+     * Add a 'must not' statement to the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  string  $boolean
+     * @return self
+     */
+    public function whereNot($query, $boolean = 'and'): self
+    {
+        $type = 'Not';
+
+        call_user_func($query, $query = $this->newQuery());
+
+        $this->wheres[] = compact('query', 'type', 'boolean');
+
+        return $this;
+    }
+
+    /**
      * Add a prefix query
      *
      * @param  string  $column

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -609,7 +609,35 @@ class QueryGrammar extends BaseGrammar
 
         $query['nested'] = array_merge($query['nested'], array_filter($wheres));
 
+        if (isset($where['operator']) && $where['operator'] === '!=') {
+            $query = [
+                'bool' => [
+                    'must_not' => [
+                        $query
+                    ]
+                ]
+            ];
+        }
+
         return $query;
+    }
+
+    /**
+     * Compile a where not clause
+     *
+     * @param  Builder  $builder
+     * @param  array  $where
+     * @return array
+     */
+    protected function compileWhereNot(Builder $builder, $where): array
+    {
+        return [
+            'bool' => [
+                'must_not' => [
+                    $this->compileWheres($where['query'])['query']
+                ]
+            ]
+        ];
     }
 
     /**


### PR DESCRIPTION
I needed to do a 'not nested doc' query, but `whereNestedDoc` doesn't currently support passing an operator, and annoyingly it would mean a braking change to add the `$operator` var in the standard order in args. Adding a more generic `whereNot()` method like this offers the same functionality, and just wraps the given query in a `must_not` query.