### PR TITLE
fix: use deleteByQuery to allow multiple deletes

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -165,7 +165,7 @@ class Connection extends BaseConnection
         return $this->run(
             $query,
             $bindings,
-            Closure::fromCallable([$this->connection, 'delete'])
+            Closure::fromCallable([$this->connection, 'deleteByQuery'])
         );
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -759,7 +759,7 @@ class QueryBuilder extends BaseBuilder
 
         $result = $this->connection->delete($this->grammar->compileDelete($this));
 
-        return !empty($result['found']);
+        return !empty($result['deleted']);
     }
 
     public function __call($method, $parameters)

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1133,20 +1133,7 @@ class QueryGrammar extends BaseGrammar
      */
     public function compileDelete(Builder $builder): array
     {
-        $params = [
-            'index' => $builder->from . $this->indexSuffix,
-            'id'    => (string) $builder->wheres[0]['value']
-        ];
-
-        if ($routing = $builder->getRouting()) {
-            $params['routing'] = $routing;
-        }
-
-        if ($parentId = $builder->getParentId()) {
-            $params['parent'] = $parentId;
-        }
-
-        return $params;
+        return $this->compileSelect($builder);
     }
 
     /**


### PR DESCRIPTION
As title says, this PR makes the package use (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html)[delete_by_query] instead of deleting by ID.
This allows the package delete multiple documents at once.